### PR TITLE
HACK: arm64: add CNTPCT_EL0 trap handler

### DIFF
--- a/arch/arm64/kernel/traps.c
+++ b/arch/arm64/kernel/traps.c
@@ -403,6 +403,19 @@ static void cntfrq_read_handler(unsigned int esr, struct pt_regs *regs)
 	regs->pc += 4;
 }
 
+static void cntpct_read_handler(unsigned int esr, struct pt_regs *regs)
+{
+	int rt = (esr & ESR_ELx_SYS64_ISS_RT_MASK) >> ESR_ELx_SYS64_ISS_RT_SHIFT;
+
+	isb();
+	if (rt != 31)
+		regs->regs[rt] = arch_counter_get_cntpct();
+	regs->pc += 4;
+}
+
+#define ESR_ELx_SYS64_ISS_SYS_CNTPCT    (ESR_ELx_SYS64_ISS_SYS_VAL(3, 3, 1, 14, 0) | \
+                                         ESR_ELx_SYS64_ISS_DIR_READ)
+
 asmlinkage void __exception do_sysinstr(unsigned int esr, struct pt_regs *regs)
 {
 	if ((esr & ESR_ELx_SYS64_ISS_SYS_OP_MASK) == ESR_ELx_SYS64_ISS_SYS_CNTVCT) {
@@ -410,6 +423,9 @@ asmlinkage void __exception do_sysinstr(unsigned int esr, struct pt_regs *regs)
 		return;
 	} else if ((esr & ESR_ELx_SYS64_ISS_SYS_OP_MASK) == ESR_ELx_SYS64_ISS_SYS_CNTFRQ) {
 		cntfrq_read_handler(esr, regs);
+		return;
+	} else if ((esr & ESR_ELx_SYS64_ISS_SYS_OP_MASK) == ESR_ELx_SYS64_ISS_SYS_CNTPCT) {
+		cntpct_read_handler(esr, regs);
 		return;
 	}
 


### PR DESCRIPTION
The upstream kernel deliberately blocks EL0 access to CNTPCT.  However
Qualcomm's time_daemon attempts to read from CNTPCT_EL0, and Qualcomm
has forked the ARM architectured timer driver to allow this to succeed.

As a workaround, add a trap handler for CNTPCT similar to the existing
one for CNTVCT.

Bug: 68266545
Change-Id: Id49b60ebdeca84fab655079c8c22afd3171371b0